### PR TITLE
Add button linking to BraneScript Docs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import braneLogo from '/branelogo.png'
 import './App.css'
 import GitPreview from './components/gitopengraph'
+import Button from './components/button'
 
 function App() {
 
@@ -11,13 +12,12 @@ function App() {
                 <h1>Brane Engine</h1>
                 <h2>The framework for building self-hosted multiplayer VR platforms</h2>
                 <br />
+                <Button
+                    label="BraneScript Docs"
+                    href="https://scripting.thebrane.org"
+                />
                 <p>I'm still working on these sites, so in the meantime check out the projects open source repos!</p>
                 <br />
-                <a href="https://scripting.thebrane.org" target="_blank" rel="noopener noreferrer">
-                    <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-2">
-                        BraneScript Docs
-                    </button>
-                </a>
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"BraneEngine"} />
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"BraneScript"} />
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"TreeSitterBraneScript"} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,12 @@ function App() {
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"BraneEngine"} />
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"BraneScript"} />
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"TreeSitterBraneScript"} />
+                <br />
+                <a href="https://scripting.thebrane.org" target="_blank" rel="noopener noreferrer">
+                    <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                        BraneScript Docs
+                    </button>
+                </a>
             </div>
         </>
     )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,15 +13,15 @@ function App() {
                 <br />
                 <p>I'm still working on these sites, so in the meantime check out the projects open source repos!</p>
                 <br />
+                <a href="https://scripting.thebrane.org" target="_blank" rel="noopener noreferrer">
+                    <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-2">
+                        BraneScript Docs
+                    </button>
+                </a>
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"BraneEngine"} />
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"BraneScript"} />
                 <GitPreview className={"mx-auto overflow-clip rounded-xl m-2 block max-w-[50%]"} owner={"WireWhiz"} repo={"TreeSitterBraneScript"} />
                 <br />
-                <a href="https://scripting.thebrane.org" target="_blank" rel="noopener noreferrer">
-                    <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-                        BraneScript Docs
-                    </button>
-                </a>
             </div>
         </>
     )

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,0 +1,9 @@
+export default function Button(props: { label: string, href: string }) {
+    return (
+        <a href={props.href} target="_blank" rel="noopener noreferrer">
+            <button className="bg-brane-green hover:bg-brane-green-700 text-white font-bold py-2 px-4 rounded mb-2">
+                {props.label}
+            </button>
+        </a>
+    )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,21 @@ export default {
         "./src/**/*.{html,js,jsx,ts,tsx}"
     ],
     theme: {
-        extend: {},
+        extend: {
+            colors: {
+                "brane-green": {
+                    DEFAULT: "#67ab00",
+                    50: "#f4f9e6",
+                    100: "#eef6d0",
+                    200: "#d6e9a1",
+                    300: "#bedc71",
+                    400: "#8fbf12",
+                    500: "#67ab00",
+                    600: "#5f9900",
+                    700: "#4f8100",
+                }
+            }
+        },
     },
     plugins: [],
 }


### PR DESCRIPTION
Add a button that links to BraneScript Docs (scripting.thebrane.org).

![image](https://github.com/user-attachments/assets/7ee23385-bd55-4c2e-8d87-e1da96012fe6)
